### PR TITLE
Upgrade faraday and VCR, resolve multi_json conflict

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use 1.9.2
+rvm use 1.9.2@pingdom-cap --create

--- a/lib/pingdom_cap/client.rb
+++ b/lib/pingdom_cap/client.rb
@@ -20,8 +20,8 @@ module PingdomCap
         builder.response :logger if options[:logger]
         builder.adapter Faraday.default_adapter
         builder.request  :url_encoded
-        builder.use Faraday::Response::Mashify
-        builder.use Faraday::Response::ParseJson
+        builder.use FaradayMiddleware::Mashify
+        builder.use FaradayMiddleware::ParseJson
       end
       @connection.basic_auth(options[:username], options[:password])
     end

--- a/lib/pingdom_cap/version.rb
+++ b/lib/pingdom_cap/version.rb
@@ -1,4 +1,4 @@
 module PingdomCap
   # Follow http://semver.org/
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/pingdom-cap.gemspec
+++ b/pingdom-cap.gemspec
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',     '~> 0.9.2'
   s.add_development_dependency 'rspec',    '~> 2.8.0'
   s.add_development_dependency 'mocha',    '~> 0.10.0'
-  s.add_development_dependency 'webmock',  '~> 1.7.10'
+  s.add_development_dependency 'webmock',  '~> 1.8.0'
   s.add_development_dependency 'cucumber', '~> 1.1.4'
   s.add_development_dependency 'aruba',    '~> 0.4.11'
-  s.add_development_dependency 'vcr',      '2.0.0.rc1'
+  s.add_development_dependency 'vcr',      '2.2.1'
 end

--- a/pingdom-cap.gemspec
+++ b/pingdom-cap.gemspec
@@ -19,10 +19,9 @@ Gem::Specification.new do |s|
   
   s.add_dependency 'awesome_print',        '~> 1.0.2'
   s.add_dependency 'capistrano',           '>= 2.9.0'
-  s.add_dependency 'faraday',              [ '>= 0.7.5', '< 0.8' ]
-  s.add_dependency 'faraday_middleware',   [ '>=  0.7',  '< 0.8' ]
+  s.add_dependency 'faraday',              '>= 0.8.1'
+  s.add_dependency 'faraday_middleware',   '>= 0.8.7'
   s.add_dependency 'hashie',               '~> 1.2.0'
-  s.add_dependency 'multi_json',           '~> 1.0.4'
 
   s.add_development_dependency 'rake',     '~> 0.9.2'
   s.add_development_dependency 'rspec',    '~> 2.8.0'


### PR DESCRIPTION
The gemspec for pingdom-cap specifies old versions for several dependencies which conflict with the gems in a Rails app I want to use it with (faraday and multi_json, specifically).

To resolve this I've simplified the dependencies and upgraded faraday, faraday_middleware, and VCR.

Two commits for bumping version and updating the .rvmrc are included that you may want to pick around.
